### PR TITLE
removing output of connection string for security purposes.

### DIFF
--- a/src/NServiceBus.MongoDB/Internals/MongoHelpers.cs
+++ b/src/NServiceBus.MongoDB/Internals/MongoHelpers.cs
@@ -44,8 +44,6 @@ namespace NServiceBus.MongoDB.Internals
                 var connectionString =
                     settings.Get<string>(MongoPersistenceConstants.ConnectionStringKey).AssumedNotNullOrWhiteSpace();
 
-                Logger.InfoFormat("Using connection string specified using .SetConnectionString: {0}", connectionString);
-
                 return connectionString;
             }
 


### PR DESCRIPTION
Having the connection string with username/password output in the log file is a security concern.  Most of the teams have access to the log files, but not to the app.config, so they normally do not see the passwords.